### PR TITLE
Python3 support and configurable endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ This extension provides a CKAN Harvest plugin that consumes metadata from Socrat
 
         ckan.plugins = harvest socrata_harvester
 
+## Usage
+
+Create a new harvest source of type "Socrata" and enter the URL of the Socrata catalog you want to harvest from. The default base url to retrieve catalogues is "https://api.us.socrata.com/api/catalog/v1". You can provide a config object to the harvester to change this base url. For example:
+
+```json
+{
+  "base_url": "https://api.eu.socrata.com/api/catalog/v1"
+}
+```
+
+For local development, run
+
+```bash
+ckan harvester gather-consumer
+ckan harvester fetch-consumer
+```
+
+to see the harvest jobs being processed.
+
 ## Copying and License
 
 This material is copyright (c) Open Knowledge International.

--- a/ckanext/socrata/plugin.py
+++ b/ckanext/socrata/plugin.py
@@ -161,7 +161,8 @@ class SocrataHarvester(HarvesterBase):
             'owner_org': local_org,
             'resources': [],
         }
-
+        log.info(package_dict)
+        log.info(res)
         # Add tags
         package_dict['tags'] = \
             [{'name': munge_tag(t)}
@@ -214,20 +215,20 @@ class SocrataHarvester(HarvesterBase):
             'url': DOWNLOAD_ENDPOINT_TEMPLATE.format(
                 domain=urlparse(harvest_object.source.url).hostname,
                 resource_id=res['resource']['id']),
-            'format': 'CSV'
+            'format': 'CSV',
+            'name': res['resource']['name']
         }]
 
         return package_dict
     
     def _set_config(self, config_str):
+        self.config = {'base_api_endpoint':BASE_API_ENDPOINT}
         if config_str:
-            self.config = self.validate_config(config_str)
+            self.config = json.loads(config_str)
             if 'base_api_endpoint' in self.config:
                 self.base_api_endpoint = self.config['base_api_endpoint']
 
             log.debug('Using config: %r', self.config)
-        else:
-            self.config = {'base_api_endpoint':BASE_API_ENDPOINT}
 
     def validate_config(self, config):
         if not config:
@@ -241,7 +242,7 @@ class SocrataHarvester(HarvesterBase):
                 raise ValueError('base_api_endpoint must be a valid URL')
             if not parsed.scheme or not parsed.netloc:
                 raise ValueError('base_api_endpoint must be a valid URL')
-        return config_obj
+        return config
     
     def process_package(self, package, harvest_object):
         '''
@@ -319,6 +320,7 @@ class SocrataHarvester(HarvesterBase):
                                     extras=[HarvestObjectExtra(
                                                         key='status',
                                                         value='hi!')])
+                log.debug('Content is {}'.format(json.dumps(d)))
                 obj.save()
                 obj_ids.append(obj.id)
                 guids.append(d['resource']['id'])
@@ -454,3 +456,5 @@ class SocrataHarvester(HarvesterBase):
                 return False
 
         return True
+
+

--- a/ckanext/socrata/plugin.py
+++ b/ckanext/socrata/plugin.py
@@ -161,8 +161,6 @@ class SocrataHarvester(HarvesterBase):
             'owner_org': local_org,
             'resources': [],
         }
-        log.info(package_dict)
-        log.info(res)
         # Add tags
         package_dict['tags'] = \
             [{'name': munge_tag(t)}
@@ -320,7 +318,6 @@ class SocrataHarvester(HarvesterBase):
                                     extras=[HarvestObjectExtra(
                                                         key='status',
                                                         value='hi!')])
-                log.debug('Content is {}'.format(json.dumps(d)))
                 obj.save()
                 obj_ids.append(obj.id)
                 guids.append(d['resource']['id'])

--- a/ckanext/socrata/plugin.py
+++ b/ckanext/socrata/plugin.py
@@ -2,14 +2,23 @@ from __future__ import unicode_literals
 
 import json
 import uuid
-from urlparse import urlparse
-
 import requests
 from dateutil.parser import parse
-from simplejson.scanner import JSONDecodeError
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+try:
+    from json import JSONDecodeError
+except ImportError:
+    from simplejson.scanner import JSONDecodeError
+
+
 
 from ckan import model
-from ckan.lib.munge import munge_title_to_name, munge_tag
+from ckan.lib.munge import munge_tag
 from ckan.plugins.core import implements
 import ckan.plugins.toolkit as toolkit
 from ckanext.harvest.interfaces import IHarvester
@@ -209,7 +218,31 @@ class SocrataHarvester(HarvesterBase):
         }]
 
         return package_dict
+    
+    def _set_config(self, config_str):
+        if config_str:
+            self.config = self.validate_config(config_str)
+            if 'base_api_endpoint' in self.config:
+                self.base_api_endpoint = self.config['base_api_endpoint']
 
+            log.debug('Using config: %r', self.config)
+        else:
+            self.config = {'base_api_endpoint':BASE_API_ENDPOINT}
+
+    def validate_config(self, config):
+        if not config:
+            return config
+
+        config_obj = json.loads(config)
+        if 'base_api_endpoint' in config_obj:
+            try:
+                parsed = urlparse(config_obj['base_api_endpoint'])
+            except AttributeError:
+                raise ValueError('base_api_endpoint must be a valid URL')
+            if not parsed.scheme or not parsed.netloc:
+                raise ValueError('base_api_endpoint must be a valid URL')
+        return config_obj
+    
     def process_package(self, package, harvest_object):
         '''
         Subclasses can override this method to perform additional processing on
@@ -237,7 +270,7 @@ class SocrataHarvester(HarvesterBase):
             api_request_url = \
                 '{0}?domains={1}&search_context={1}' \
                 '&only=datasets&limit={2}&offset={3}' \
-                .format(BASE_API_ENDPOINT, domain, limit, offset)
+                .format(self.base_api_endpoint, domain, limit, offset)
             log.debug('Requesting {}'.format(api_request_url))
             api_response = requests.get(api_request_url)
 
@@ -266,8 +299,9 @@ class SocrataHarvester(HarvesterBase):
                     _request_datasets_from_socrata(domain, batch_number,
                                                    current_offset)
                 if datasets is None or len(datasets) == 0:
-                    raise StopIteration
+                    break
                 current_offset = current_offset + batch_number
+                log.debug(f'Continued with {current_offset}-{batch_number}')
                 for dataset in datasets:
                     yield dataset
 
@@ -292,7 +326,7 @@ class SocrataHarvester(HarvesterBase):
 
         log.debug('In SocrataHarvester gather_stage (%s)',
                   harvest_job.source.url)
-
+        self._set_config(harvest_job.source.config)
         domain = urlparse(harvest_job.source.url).hostname
 
         object_ids, guids = _make_harvest_objs(_page_datasets(domain, 100))
@@ -396,7 +430,7 @@ class SocrataHarvester(HarvesterBase):
 
         else:
             # We need to explicitly provide a package ID
-            package_dict['id'] = unicode(uuid.uuid4())
+            package_dict['id'] = str(uuid.uuid4())
 
             harvest_object.package_id = package_dict['id']
             harvest_object.add()

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
 
 


### PR DESCRIPTION
This adds a couple of small changes to make the plugin work with python 3. We also needed to be able to change the endpoint the harvester uses (the datasets we wanted were on the .eu version), so `base_api_endpoint` has been added as a configuration option.

I can see the repo hasn't been updated for a while! But it only took small changes to get this working, and if we need it someone else might, so hopefully this pull request is useful